### PR TITLE
Added ZIO http4s handler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val root = project
   .in(file("."))
   .settings(commonSettings)
   .settings(noPublishSettings)
-  .aggregate(common, tests, http4s, akka, exampleHttp4s, exampleAkka)
+  .aggregate(common, tests, http4s, http4sZio, akka, exampleHttp4s, exampleAkka)
 
 lazy val CirceVersion = "0.12.1"
 lazy val ScalaTestVersion = "3.1.0"
@@ -70,6 +70,29 @@ lazy val http4s = project
   )
   .dependsOn(common)
   .dependsOn(tests % "test")
+
+lazy val http4sZio = project
+  .in(file("http4s-lambda-zio"))
+  .settings(publishSettings)
+  .settings(commonSettings)
+  .settings(
+    name := "http4s-lambda",
+    moduleName := "http4s-lambda",
+    scalacOptions := scalacVersionOptions(scalaVersion.value),
+    libraryDependencies ++= {
+      Seq(
+        "org.http4s" %% "http4s-core" % Http4sVersion,
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % "test",
+        "org.http4s" %% "http4s-dsl" % Http4sVersion % "test",
+        "org.http4s" %% "http4s-circe" % Http4sVersion % "test",
+        "dev.zio" %% "zio" % "1.0.0-RC14",
+        "dev.zio" %% "zio-interop-cats" % "2.0.0.0-RC5"
+      )
+    }
+  )
+  .dependsOn(common)
+  .dependsOn(tests % "test")
+  .dependsOn(http4s % "test->test;compile->compile")
 
 lazy val akka = project
   .in(file("akka-http-lambda"))

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val http4s = project
   .settings(
     name := "http4s-lambda",
     moduleName := "http4s-lambda",
-    scalacOptions := scalacVersionOptions(scalaVersion.value),
+    scalacOptions ++= scalacVersionOptions(scalaVersion.value),
     libraryDependencies ++= {
       Seq(
         "org.http4s" %% "http4s-core" % Http4sVersion,
@@ -78,7 +78,7 @@ lazy val http4sZio = project
   .settings(
     name := "http4s-lambda-zio",
     moduleName := "http4s-lambda-zio",
-    scalacOptions := scalacVersionOptions(scalaVersion.value),
+    scalacOptions ++= scalacVersionOptions(scalaVersion.value),
     libraryDependencies ++= {
       Seq(
         "org.http4s" %% "http4s-core" % Http4sVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -76,8 +76,8 @@ lazy val http4sZio = project
   .settings(publishSettings)
   .settings(commonSettings)
   .settings(
-    name := "http4s-lambda",
-    moduleName := "http4s-lambda",
+    name := "http4s-lambda-zio",
+    moduleName := "http4s-lambda-zio",
     scalacOptions := scalacVersionOptions(scalaVersion.value),
     libraryDependencies ++= {
       Seq(

--- a/http4s-lambda-zio/src/main/scala/io/github/howardjohn/lambda/http4szio/Http4sLambdaHandlerZIO.scala
+++ b/http4s-lambda-zio/src/main/scala/io/github/howardjohn/lambda/http4szio/Http4sLambdaHandlerZIO.scala
@@ -6,7 +6,7 @@ import org.http4s._
 import zio._
 import zio.interop.catz._
 
-case class Http4sLambdaHandlerZIO(service: HttpRoutes[Task]) extends Http4sLambdaHandlerK[Task] {
+class Http4sLambdaHandlerZIO(val service: HttpRoutes[Task]) extends Http4sLambdaHandlerK[Task] {
   val runtime: DefaultRuntime = new DefaultRuntime {}
 
   def handleRequest(request: ProxyRequest): ProxyResponse =

--- a/http4s-lambda-zio/src/main/scala/io/github/howardjohn/lambda/http4szio/Http4sLambdaHandlerZIO.scala
+++ b/http4s-lambda-zio/src/main/scala/io/github/howardjohn/lambda/http4szio/Http4sLambdaHandlerZIO.scala
@@ -1,0 +1,17 @@
+package io.github.howardjohn.lambda.http4szio
+
+import io.github.howardjohn.lambda.ProxyEncoding._
+import io.github.howardjohn.lambda.http4s.Http4sLambdaHandlerK
+import org.http4s._
+import zio._
+import zio.interop.catz._
+
+case class Http4sLambdaHandlerZIO(service: HttpRoutes[Task]) extends Http4sLambdaHandlerK[Task] {
+  val runtime: DefaultRuntime = new DefaultRuntime {}
+
+  def handleRequest(request: ProxyRequest): ProxyResponse =
+    parseRequest(request)
+      .map(runRequest)
+      .flatMap(request => runtime.unsafeRun(request.either))
+      .fold(errorResponse, identity)
+}

--- a/http4s-lambda-zio/src/test/scala/io/github/howardjohn/lambda/http4szio/Http4sLambdaHandlerZIOSpec.scala
+++ b/http4s-lambda-zio/src/test/scala/io/github/howardjohn/lambda/http4szio/Http4sLambdaHandlerZIOSpec.scala
@@ -1,0 +1,20 @@
+package io.github.howardjohn.lambda.http4szio
+
+import io.circe.generic.auto._
+import io.github.howardjohn.lambda.LambdaHandlerBehavior
+import io.github.howardjohn.lambda.LambdaHandlerBehavior._
+import io.github.howardjohn.lambda.http4s.TestRoutes
+import org.http4s.circe._
+import org.http4s.EntityDecoder
+import org.scalatest.{FeatureSpec, GivenWhenThen}
+import zio._
+import zio.interop.catz._
+import zio.interop.catz.implicits._
+
+class Http4sLambdaHandlerZIOSpec extends FeatureSpec with LambdaHandlerBehavior with GivenWhenThen {
+  implicit val jsonDecoder: EntityDecoder[Task, JsonBody] = jsonOf[Task, JsonBody]
+
+  val handler = new Http4sLambdaHandlerZIO(new TestRoutes[Task].routes)
+
+  scenariosFor(behavior(handler))
+}

--- a/http4s-lambda/src/main/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandler.scala
+++ b/http4s-lambda/src/main/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandler.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import io.github.howardjohn.lambda.ProxyEncoding._
 import org.http4s._
 
-case class Http4sLambdaHandler(service: HttpRoutes[IO]) extends Http4sLambdaHandlerK[IO] {
+class Http4sLambdaHandler(val service: HttpRoutes[IO]) extends Http4sLambdaHandlerK[IO] {
   def handleRequest(request: ProxyRequest): ProxyResponse =
     parseRequest(request)
       .map(runRequest)

--- a/http4s-lambda/src/main/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandler.scala
+++ b/http4s-lambda/src/main/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandler.scala
@@ -1,64 +1,13 @@
 package io.github.howardjohn.lambda.http4s
 
 import cats.effect.IO
-import fs2.{text, Stream}
 import io.github.howardjohn.lambda.ProxyEncoding._
-import io.github.howardjohn.lambda.{LambdaHandler, ProxyEncoding}
 import org.http4s._
 
-import scala.util.Try
-
-class Http4sLambdaHandler(service: HttpRoutes[IO]) extends LambdaHandler {
-  import Http4sLambdaHandler._
-
-  override def handleRequest(request: ProxyRequest): ProxyResponse =
+case class Http4sLambdaHandler(service: HttpRoutes[IO]) extends Http4sLambdaHandlerK[IO] {
+  def handleRequest(request: ProxyRequest): ProxyResponse =
     parseRequest(request)
       .map(runRequest)
       .flatMap(_.attempt.unsafeRunSync())
       .fold(errorResponse, identity)
-
-  private def runRequest(request: Request[IO]): IO[ProxyResponse] =
-    Try {
-      service
-        .run(request)
-        .getOrElse(Response.notFound)
-        .flatMap(asProxyResponse)
-    }.fold(errorResponse.andThen(e => IO(e)), identity)
-}
-
-private object Http4sLambdaHandler {
-  private val errorResponse = (err: Throwable) => ProxyResponse(500, Map.empty, err.getMessage)
-
-  private def asProxyResponse(resp: Response[IO]): IO[ProxyResponse] =
-    resp
-      .as[String]
-      .map { body =>
-        ProxyResponse(
-          resp.status.code,
-          resp.headers.toList
-            .map(h => h.name.value -> h.value)
-            .toMap,
-          body)
-      }
-
-  private def parseRequest(request: ProxyRequest): Either[ParseFailure, Request[IO]] =
-    for {
-      uri <- Uri.fromString(ProxyEncoding.reconstructPath(request))
-      method <- Method.fromString(request.httpMethod)
-    } yield
-      Request[IO](
-        method,
-        uri,
-        headers = request.headers.map(toHeaders).getOrElse(Headers.empty),
-        body = request.body.map(encodeBody).getOrElse(EmptyBody)
-      )
-
-  private def toHeaders(headers: Map[String, String]): Headers =
-    Headers {
-      headers.map {
-        case (k, v) => Header(k, v)
-      }.toList
-    }
-
-  private def encodeBody(body: String) = Stream(body).through(text.utf8Encode)
 }

--- a/http4s-lambda/src/main/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandlerK.scala
+++ b/http4s-lambda/src/main/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandlerK.scala
@@ -1,0 +1,61 @@
+package io.github.howardjohn.lambda.http4s
+
+import cats.{Applicative, MonadError}
+import io.github.howardjohn.lambda.{LambdaHandler, ProxyEncoding}
+import io.github.howardjohn.lambda.ProxyEncoding.{ProxyRequest, ProxyResponse}
+import org.http4s._
+import fs2.{Pure, Stream, text}
+import cats.implicits._
+
+import scala.util.Try
+
+trait Http4sLambdaHandlerK[F[_]] extends LambdaHandler {
+  val service: HttpRoutes[F]
+
+  def handleRequest(request: ProxyRequest)(implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, String]): ProxyResponse = ???
+
+  def runRequest(request: Request[F])(implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, String]): F[ProxyResponse] =
+    Try {
+      service
+        .run(request)
+        .getOrElse(Response.notFound)
+        .flatMap(asProxyResponse)
+    }.fold(errorResponse.andThen(e => Applicative[F].pure(e)), identity)
+
+  protected val errorResponse = (err: Throwable) => ProxyResponse(500, Map.empty, err.getMessage)
+
+  protected def asProxyResponse(resp: Response[F])(implicit F: MonadError[F, Throwable],
+                                                   decoder: EntityDecoder[F, String]): F[ProxyResponse] =
+    resp
+      .as[String]
+      .map { body =>
+        ProxyResponse(
+          resp.status.code,
+          resp.headers.toList
+            .map(h => h.name.value -> h.value)
+            .toMap,
+          body)
+      }
+
+  protected def parseRequest(request: ProxyRequest): Either[ParseFailure, Request[F]] =
+    for {
+      uri <- Uri.fromString(ProxyEncoding.reconstructPath(request))
+      method <- Method.fromString(request.httpMethod)
+    } yield
+      Request[F](
+        method,
+        uri,
+        headers = request.headers.map(toHeaders).getOrElse(Headers.empty),
+        body = request.body.map(encodeBody).getOrElse(EmptyBody)
+      )
+
+  protected def toHeaders(headers: Map[String, String]): Headers =
+    Headers {
+      headers.map {
+        case (k, v) => Header(k, v)
+      }.toList
+    }
+
+  protected def encodeBody(body: String): Stream[Pure, Byte] = Stream(body).through(text.utf8Encode)
+}
+

--- a/http4s-lambda/src/main/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandlerK.scala
+++ b/http4s-lambda/src/main/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandlerK.scala
@@ -12,9 +12,10 @@ import scala.util.Try
 trait Http4sLambdaHandlerK[F[_]] extends LambdaHandler {
   val service: HttpRoutes[F]
 
-  def handleRequest(request: ProxyRequest)(implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, String]): ProxyResponse = ???
+  def handleRequest(request: ProxyRequest): ProxyResponse
 
-  def runRequest(request: Request[F])(implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, String]): F[ProxyResponse] =
+  def runRequest(request: Request[F])(implicit F: MonadError[F, Throwable],
+                                      decoder: EntityDecoder[F, String]): F[ProxyResponse] =
     Try {
       service
         .run(request)

--- a/http4s-lambda/src/test/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandlerSpec.scala
+++ b/http4s-lambda/src/test/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandlerSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{FeatureSpec, GivenWhenThen}
 class Http4sLambdaHandlerSpec extends FeatureSpec with LambdaHandlerBehavior with GivenWhenThen {
   implicit val jsonDecoder: EntityDecoder[IO, JsonBody] = jsonOf[IO, JsonBody]
 
-  val handler = Http4sLambdaHandler(new TestRoutes[IO].routes)
+  val handler = new Http4sLambdaHandler(new TestRoutes[IO].routes)
 
   scenariosFor(behavior(handler))
 }

--- a/http4s-lambda/src/test/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandlerSpec.scala
+++ b/http4s-lambda/src/test/scala/io/github/howardjohn/lambda/http4s/Http4sLambdaHandlerSpec.scala
@@ -2,37 +2,16 @@ package io.github.howardjohn.lambda.http4s
 
 import cats.effect.IO
 import io.circe.generic.auto._
-import io.circe.syntax._
 import io.github.howardjohn.lambda.LambdaHandlerBehavior
 import io.github.howardjohn.lambda.LambdaHandlerBehavior._
+import org.http4s.EntityDecoder
 import org.http4s.circe._
-import org.http4s.dsl.io._
-import org.http4s.{EntityDecoder, Header, HttpRoutes}
 import org.scalatest.{FeatureSpec, GivenWhenThen}
 
 class Http4sLambdaHandlerSpec extends FeatureSpec with LambdaHandlerBehavior with GivenWhenThen {
   implicit val jsonDecoder: EntityDecoder[IO, JsonBody] = jsonOf[IO, JsonBody]
 
-  object TimesQueryMatcher extends OptionalQueryParamDecoderMatcher[Int]("times")
-
-  val route: HttpRoutes[IO] = HttpRoutes.of[IO] {
-    case GET -> Root / "hello" :? TimesQueryMatcher(times) =>
-      Ok {
-        Seq
-          .fill(times.getOrElse(1))("Hello World!")
-          .mkString(" ")
-      }
-    case GET -> Root / "long" => IO(Thread.sleep(1000)).flatMap(_ => Ok("Hello World!"))
-    case GET -> Root / "exception" => throw RouteException()
-    case GET -> Root / "error" => InternalServerError()
-    case req @ GET -> Root / "header" =>
-      val header = req.headers.find(h => h.name.value == inputHeader).map(_.value).getOrElse("Header Not Found")
-      Ok(header, Header(outputHeader, outputHeaderValue))
-    case req @ POST -> Root / "post" => req.as[String].flatMap(s => Ok(s))
-    case req @ POST -> Root / "json" => req.as[JsonBody].flatMap(s => Ok(LambdaHandlerBehavior.jsonReturn.asJson))
-  }
-
-  val handler = new Http4sLambdaHandler(route)
+  val handler = Http4sLambdaHandler(new TestRoutes[IO].routes)
 
   scenariosFor(behavior(handler))
 }

--- a/http4s-lambda/src/test/scala/io/github/howardjohn/lambda/http4s/TestRoutes.scala
+++ b/http4s-lambda/src/test/scala/io/github/howardjohn/lambda/http4s/TestRoutes.scala
@@ -1,0 +1,44 @@
+package io.github.howardjohn.lambda.http4s
+
+import cats.{Applicative, MonadError}
+import cats.effect.Sync
+import cats.implicits._
+import io.github.howardjohn.lambda.LambdaHandlerBehavior
+import io.github.howardjohn.lambda.LambdaHandlerBehavior._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.{EntityDecoder, Header, HttpRoutes}
+import org.http4s.circe._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.http4s.dsl.impl.OptionalQueryParamDecoderMatcher
+
+class TestRoutes[F[_]] {
+
+  object TimesQueryMatcher extends OptionalQueryParamDecoderMatcher[Int]("times")
+
+  val dsl = Http4sDsl[F]
+
+  import dsl._
+
+  def routes(implicit sync: Sync[F],
+             jsonDecoder: EntityDecoder[F, JsonBody],
+             me: MonadError[F, Throwable],
+             stringDecoder: EntityDecoder[F, String],
+             ap: Applicative[F]): HttpRoutes[F] = HttpRoutes.of[F] {
+    case GET -> Root / "hello" :? TimesQueryMatcher(times) =>
+      Ok {
+        Seq
+          .fill(times.getOrElse(1))("Hello World!")
+          .mkString(" ")
+      }
+    case GET -> Root / "long" => Applicative[F].pure(Thread.sleep(1000)).flatMap(_ => Ok("Hello World!"))
+    case GET -> Root / "exception" => throw RouteException()
+    case GET -> Root / "error" => InternalServerError()
+    case req@GET -> Root / "header" =>
+      val header = req.headers.find(h => h.name.value == inputHeader).map(_.value).getOrElse("Header Not Found")
+      Ok(header, Header(outputHeader, outputHeaderValue))
+    case req@POST -> Root / "post" => req.as[String].flatMap(s => Ok(s))
+    case req@POST -> Root / "json" => req.as[JsonBody].flatMap(s => Ok(LambdaHandlerBehavior.jsonReturn.asJson))
+  }
+
+}


### PR DESCRIPTION
Extracted as much code where the effect type could be generalised into the trait: `Http4sLambdaHandlerK`. Also generalised the effect type of the Http4sRoutes used in the tests. Also added a ZIO http4s handler class.