### PR TITLE
Enable automated release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 target
 .idea
+
+# Metals IDE specific
+project/metals.sbt
+.bloop
+.metals

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: scala
 
-scala:
-  - 2.12.10
-  - 2.13.1
-
 before_install:
   - git fetch --tags
 
@@ -15,9 +11,9 @@ stages:
 jobs:
   include:
     - stage: test
-    - name: compile
-      script: sbt compile
-    - name: formatting
-      script: ./bin/scalafmt --test
+    - name: compile and test
+      script: sbt +compile +test
+    # - name: formatting
+    # script: ./bin/scalafmt --test
     - stage: release # Only runs if previous stages pass
       script: sbt ci-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,22 @@ language: scala
 
 scala:
   - 2.12.10
+  - 2.13.1
+
+before_install:
+  - git fetch --tags
+
+stages:
+  - name: test
+  - name: release
+    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+
+jobs:
+  include:
+    - stage: test
+    - name: compile
+      script: sbt compile
+    - name: formatting
+      script: ./bin/scalafmt --test
+    - stage: release # Only runs if previous stages pass
+      script: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,8 @@ def scalacVersionOptions(scalaVersion: String) =
   }
 
 lazy val commonSettings = Seq(
-  organization := "io.github.howardjohn",
   scalaVersion := Scala212Version,
   crossScalaVersions := Seq(Scala212Version, Scala213Version),
-  version := "0.4.0"
 )
 
 lazy val root = project
@@ -20,6 +18,25 @@ lazy val root = project
   .settings(noPublishSettings)
   .aggregate(common, tests, http4s, http4sZio, akka, exampleHttp4s, exampleAkka)
 
+inThisBuild(List(
+  organization := "io.github.howardjohn",
+  homepage := Some(url("https://github.com/howardjohn/scala-server-lambda")),
+  licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
+  scmInfo := Some(
+    ScmInfo(
+      url("https://github.com/howardjohn/scala-server-lambda"),
+      "scm:git@github.com:howardjohn/scala-server-lambda.git"
+    )),
+  developers := List(
+    Developer(
+      id = "howardjohn",
+      name = "John Howard",
+      email = "johnbhoward96@gmail.com",
+      url = url("https://github.com/howardjohn/")
+    )
+  )
+))
+
 lazy val CirceVersion = "0.12.1"
 lazy val ScalaTestVersion = "3.1.0"
 lazy val Http4sVersion = "0.21.0-M5"
@@ -27,7 +44,6 @@ lazy val Http4sVersion = "0.21.0-M5"
 lazy val common = project
   .in(file("common"))
   .settings(commonSettings)
-  .settings(publishSettings)
   .settings(
     moduleName := "scala-server-lambda-common",
     libraryDependencies ++=
@@ -41,7 +57,6 @@ lazy val common = project
 lazy val tests = project
   .in(file("tests"))
   .settings(commonSettings)
-  .settings(publishSettings)
   .settings(
     moduleName := "scala-server-lambda-tests",
     libraryDependencies ++=
@@ -53,7 +68,6 @@ lazy val tests = project
 
 lazy val http4s = project
   .in(file("http4s-lambda"))
-  .settings(publishSettings)
   .settings(commonSettings)
   .settings(
     name := "http4s-lambda",
@@ -73,7 +87,6 @@ lazy val http4s = project
 
 lazy val http4sZio = project
   .in(file("http4s-lambda-zio"))
-  .settings(publishSettings)
   .settings(commonSettings)
   .settings(
     name := "http4s-lambda-zio",
@@ -96,7 +109,6 @@ lazy val http4sZio = project
 
 lazy val akka = project
   .in(file("akka-http-lambda"))
-  .settings(publishSettings)
   .settings(commonSettings)
   .settings(
     name := "akka-http-lambda",
@@ -141,38 +153,6 @@ lazy val exampleAkka = project
   .dependsOn(akka)
 
 lazy val noPublishSettings = Seq(
-  publish := {},
-  publishLocal := {},
-  publishArtifact := false
+  skip in publish := true
 )
 
-lazy val publishSettings = Seq(
-  homepage := Some(url("https://github.com/howardjohn/scala-server-lambda")),
-  licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
-  scmInfo := Some(
-    ScmInfo(
-      url("https://github.com/howardjohn/scala-server-lambda"),
-      "scm:git@github.com:howardjohn/scala-server-lambda.git"
-    )),
-  developers := List(
-    Developer(
-      id = "howardjohn",
-      name = "John Howard",
-      email = "johnbhoward96@gmail.com",
-      url = url("https://github.com/howardjohn/")
-    )
-  ),
-  credentials += Credentials(Path.userHome / ".sbt" / ".credentials"),
-  publishMavenStyle := true,
-  publishArtifact in Test := false,
-  pomIncludeRepository := { _ =>
-    false
-  },
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  }
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.0")


### PR DESCRIPTION
Added the [sbt-ci-release](https://github.com/olafurpg/sbt-ci-release) plugin to handle release automation.

@howardjohn Hopefully this PR can make it easier to automate the release process. As you are the owner of the project, there are a few small steps you would need to complete [here](https://github.com/olafurpg/sbt-ci-release#travis) 

New releases are driven off of git tags via [sbt-dynver](https://github.com/dwijnand/sbt-dynver).

Related to #12 